### PR TITLE
space_server: bird: add IPv6 prefix for Hafnium

### DIFF
--- a/roles/space_server/files/bird.conf
+++ b/roles/space_server/files/bird.conf
@@ -44,7 +44,8 @@ define graffen_prefixes_v6 = [
 
 define hafnium_prefixes_v6 = [
 	2a0e:8f02:f034::/48,
-	2a0e:8f02:2190::/48
+	2a0e:8f02:2190::/48,
+	2a0e:8f02:2191::/48
 ];
 
 # large communities


### PR DESCRIPTION
Add prefix 2a0e:8f02:2191::/48 to bird config for routing.