### PR TITLE
jumbotron: correct file path and add Hafnium as superuser

### DIFF
--- a/roles/jumbotron/tasks/fakta.yml
+++ b/roles/jumbotron/tasks/fakta.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy fakta bell script
   copy:
-    dest: '~jumbotron/fakta-bell.sh'
+    dest: '~/jumbotron/fakta-bell.sh'
     src: 'fakta-bell.sh'
     owner: jumbotron
     group: users

--- a/roles/jumbotron/vars/main.yml
+++ b/roles/jumbotron/vars/main.yml
@@ -37,5 +37,6 @@ users:
   'knielsen': sudo
   'richard': sudo
   'max': sudo
+  'hafnium': sudo
 
 # vim: set ts=2 sw=2 et:


### PR DESCRIPTION
jumbotron: correct file path
jumbotron: add hafnium as superuser

A in Linux path needs to be `~/user/` not `~user/` on Linux.