### PR TITLE
readme: Document code contribution process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # Labitat Ansible
 
-Ansible playbooks for space infrastructure
+This repository contains configuration management that controls our infrastructure in the space as well as works as documentation on how it's all set up.
+
+## Contributing
+
+To make this ansible code maximally useful to Labitat even if people come and go, the contribution process follow general OSS contribution patterns.
+
+Basically:
+
+ - [Fork this repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to your own user on Github
+ - Commit your changes in the forked repository (following [commit message guidelines](#commit-message-guidelines)
+ - [Create a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) (PR) to labitat/labitat-ansible
+ - If you're making big changes, feel free to name your PR with [WIP] to indicate it's not ready for review yet.
+ - Respond to review comments, and implement or communicate about any suggestions.
+ - Wait for merge
+
+After contributing a few PR's, you are welcome to become a reviewer yourself :).
+
+If it's a small change and you have access, it's OK to run ansible before your PR is reviewed. Just remember to re-run if changes are made.
+
+### Commit message guidelines
+Your commit message should answer the following questions:
+ - What is the problem you're fixing?
+ - How are you solving it?
+ - What impact will this have on users / fellow coders?
+
+Additionally, split your changes so that you [solve only one problem per commit](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes). (tip: use `git add -p` to add lines interactively).
+
+In general, [Linux kernel commit guidelines](https://www.kernel.org/doc/html/latest/process/submitting-patches.html) are a good reference.
 
 ## Running ansible
 


### PR DESCRIPTION
Previously, knowledge of how to contribute ansible code has only been spread verbally, which has made it hard for new members to contribute.
This PR documents how new members can contribute, and additionally attempts to crystallise the process to make it more accessible and open.