### PR TITLE
space_server: dhcpd: Add classless static route for 10.42.0.0/16

### DIFF
--- a/roles/space_server/templates/dhcpd.conf.j2
+++ b/roles/space_server/templates/dhcpd.conf.j2
@@ -77,6 +77,12 @@ subnet 10.42.1.0 netmask 255.255.255.0 {
 	next-server 10.42.1.1;
 	filename "pxelinux.0";
 
+	# Set static route to 10.42.0.0/16
+	# Because RFC3442 tells clients to ignore default route if
+	# classless-static-route is set, we also set default route here
+	# See man dhcp-options(5)
+	option classless-static-routes 0.0.0.0/0 10.42.1.1, 10.42.0.0/16 10.42.1.1;
+
 	if exists host-name and option host-name ~= "^[0-9A-Za-z-]*$" {
 		ddns-hostname = option host-name;
 		ddns-domainname "dhcp";
@@ -100,6 +106,12 @@ subnet 10.42.2.0 netmask 255.255.255.0 {
 	next-server 10.42.2.1;
 	filename "pxelinux.0";
 
+	# Set static route to 10.42.0.0/16
+	# Because RFC3442 tells clients to ignore default route if
+	# classless-static-route is set, we also set default route here
+	# See man dhcp-options(5)
+	option classless-static-routes 0.0.0.0/0 10.42.2.1, 10.42.0.0/16 10.42.2.1;
+
 	if exists host-name and option host-name ~= "^[0-9A-Za-z-]*$" {
 		ddns-hostname = option host-name;
 		ddns-domainname "dhcp";
@@ -120,6 +132,12 @@ subnet 10.42.3.0 netmask 255.255.255.0 {
 	option routers 10.42.3.1;
 	option domain-name-servers 185.38.175.0;
 	option ntp-servers 185.38.175.0;
+
+	# Set static route to 10.42.0.0/16
+	# Because RFC3442 tells clients to ignore default route if
+	# classless-static-route is set, we also set default route here
+	# See man dhcp-options(5)
+	option classless-static-routes 0.0.0.0/0 10.42.3.1, 10.42.0.0/16 10.42.3.1;
 
 	if exists host-name and option host-name ~= "^[0-9A-Za-z-]*$" {
 		ddns-hostname = option host-name;


### PR DESCRIPTION
WIP. Request for feedback :)

Change:
Add a Classless Static Route of 10.42.0.0/16 to some subnets of the DHCP server.

Because some DHCP clients ignore default route when a Classless Static Route is set, it also sets the default route. See dhcp-options(5), RFC3442, and https://ral-arturo.org/2018/09/12/dhcp-static-route.html

Background:
When connected to Labitat wifi (10.42.2.0/24), my laptop could not speak to a wired box on 10.42.1.0/24, if my Mullvad VPN was active.
Normally, when using space_server as default route and no VPN, traffic to other subnets will be correctly routed.
But because my VPN hijacks the default route, it also wrongly hijacks traffic to other local subnets.

Questions:
 - Because we want wired boxes + users on Private wifi to be able to talk to clients on Free wifi (10.42.3.0/24), and wifi clients might also have VPN and thus be unable to reply, I also added a Classless Static Route to Free wifi. Is this actually needed? Maybe established connections will always route outside the VPN?