### PR TITLE
space_server: users: Give sudo to cadero

### DIFF
--- a/roles/space_server/vars/main.yml
+++ b/roles/space_server/vars/main.yml
@@ -61,6 +61,7 @@ users:
   'signout': sudo
   'hafnium': sudo
   'joshbuddy': sudo
+  'cadero': sudo
 
 boot:
   device: 'LABEL=BOOT'

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -91,6 +91,12 @@ userdata:
 
   'jobbe': {}
 
+  'cadero':
+    name: 'Oliver Cadero'
+    uid: 2026
+    authorized_keys:
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDErwnvNA9FhRsZqd7lFmfvQmWCvCRu6OmyOUw2WZIcjY11h/dBGOZYT4PHG42IChFcFd/RczCArC3B3Li9cI+TaNNBlVxyElZsg2L+98KeGzapPx02e/bgea9Vf1DKsC5DIhDg1ZRp5BcsY9w4l53b12EPWDTzAr87bvlowoQE8DKzkOmLi3RhFqJrCY5CJOzde5RaRbAaJby+SmqVnauS0j8PgZP3QJF4cpnbVg3gdlCB4neSyeh7btKe6X3nu4ySZuUBKDc8zipd2aJX+5xJGmMcqF/ybJxNY3yzEV+Xt/nCBHwa/X78gl3QsaV6xJfqYaUiITjGj6lXKCGi3zvabKIGV/THfFR548vBqLkzRfnUkUAXdjMyx1Aqm7U6d2hpm4cboBpz2+h6troKD38MVCCcIrdEpBUZzxxK1tCYImXO1FowTmH6qWo9/3h5t+bJEZQWp0vR73ZW01exrAseSlFGT1a1vw3PRo1lspSn/B4SuziYYnwPbCpR9ZviOw8= cadero@labitat'
+
 users: {}
 
 # vim: set ts=2 sw=2 et:


### PR DESCRIPTION
Also closes #60

I am working on setting up a DECT system in Labitat, using a Mitel RFP 44. These are configured via [DHCP](https://howto.dect.network#dhcp). To configure and maintain the future DECT network, I need sudo access to space_server, to be able to deploy new dhcpd config.